### PR TITLE
shift 默认自动切换回小写，双击可大写锁定

### DIFF
--- a/HamsterKeyboard/Keyboard/Actions/KeyboardAction+Actions.swift
+++ b/HamsterKeyboard/Keyboard/Actions/KeyboardAction+Actions.swift
@@ -19,7 +19,18 @@ extension KeyboardAction {
    The action that by default should be triggered when the
    action is double tapped.
    */
-  var hamsterStandardDoubleTapAction: GestureAction? { nil }
+  var hamsterStandardDoubleTapAction: GestureAction? {
+    switch self {
+    case .shift(let currentState):
+      return {
+        switch currentState {
+        case .lowercased: $0?.setKeyboardType(.alphabetic(.capsLocked))
+        case .auto, .capsLocked, .uppercased: $0?.setKeyboardType(.alphabetic(.lowercased))
+        }
+      }
+    default: return nil
+    }
+  }
 
   /**
    The action that by default should be triggered when the
@@ -50,7 +61,16 @@ extension KeyboardAction {
    */
   var hamsterStandardReleaseAction: GestureAction? {
     switch self {
-    case .character(let char): return { $0?.insertText(char) }
+    case .character(let char): return {
+        $0?.insertText(char)
+        if let ivc = $0, let ivc = ivc as? HamsterKeyboardViewController {
+          switch ivc.keyboardContext.keyboardType {
+          case .alphabetic(.uppercased):
+            ivc.setKeyboardType(.alphabetic(.lowercased))
+          default:
+          }
+        }
+      }
     case .characterMargin(let char): return { $0?.insertText(char) }
     case .dismissKeyboard: return { $0?.dismissKeyboard() }
     case .emoji(let emoji): return {


### PR DESCRIPTION
由于我没有 Mac, 所以无法编译测试，如果有问题请包含

另外，我看了文档后仍然不太理解 `.characterMargin` 的意思，所以没有修改这部分