### PR TITLE
回车键 "send" 的 L10N 处理

### DIFF
--- a/HamsterKeyboard/Keyboard/Actions/KeyboardAction+Return.swift
+++ b/HamsterKeyboard/Keyboard/Actions/KeyboardAction+Return.swift
@@ -10,7 +10,13 @@ extension KeyboardAction.ReturnType {
 //      return chineseReturnText()
 //    }
     switch self {
-    case .custom(let title): return title
+    case .custom(let title): {
+      // workaround until https://github.com/KeyboardKit/KeyboardKit/issues/432 resolved
+      if title == "send" {
+        return KKL10n.send.hamsterText(for: locale)
+      }
+      return title
+    }
     case .done: return KKL10n.done.hamsterText(for: locale)
     case .go: return KKL10n.go.hamsterText(for: locale)
     case .join: return KKL10n.join.hamsterText(for: locale)


### PR DESCRIPTION
KeyboardKit 没有完全实现 `UIReturnKeyType` 所有类型 (KeyboardKit/KeyboardKit#432)，其他类型可以暂时不管，但 "send" 会高频出现（微信、QQ）

我加了一个临时的处理，待上游实现后可改掉。不知道我这样改是不是正确的，麻烦 review 一下，谢谢