### PR TITLE
fix #28：跳过 IPv6 地址

### DIFF
--- a/HamsterApp/HamsterApp/View/SubView/FileManagerView.swift
+++ b/HamsterApp/HamsterApp/View/SubView/FileManagerView.swift
@@ -131,7 +131,7 @@ extension UIDevice {
           return nil
         }
         let addrFamily = interface.ifa_addr.pointee.sa_family
-        if addrFamily == UInt8(AF_INET) || addrFamily == UInt8(AF_INET6) {
+        if addrFamily == UInt8(AF_INET) {
           guard let ifa_name = interface.ifa_name else {
             return nil
           }


### PR DESCRIPTION
我这里测试的情况，IPv6 地址即使加上 `[]` 也无法访问，猜想可能跟 iOS 的防火墙有关；几乎所有局域网都有 IPv4 地址，我们可以直接跳过 IPv6 地址