### PR TITLE
Fix #16: 可选使用 hamster.yaml

### DIFF
--- a/Hamster/RimeEngine/RimeEngine.swift
+++ b/Hamster/RimeEngine/RimeEngine.swift
@@ -414,9 +414,9 @@ public extension RimeEngine {
     return rimeAPI.selectSchema(session, andSchameId: schemaId)
   }
 
-  func colorSchema() -> [ColorSchema] {
-    // open squirrel.yaml
-    let cfg = rimeAPI.openConfig("squirrel")
+  func colorSchema(_ useSquirrel: Bool = true) -> [ColorSchema] {
+    // open squirrel.yaml or hamster.yaml
+    let cfg = useSquirrel ? rimeAPI.openConfig("squirrel") : rimeAPI.openConfig("hamster")
     guard cfg != nil else {
       return []
     }
@@ -447,9 +447,9 @@ public extension RimeEngine {
     }
   }
 
-  func currentColorSchemaName() -> String {
-    // open squirrel.yaml
-    let config = rimeAPI.openConfig("squirrel")
+  func currentColorSchemaName(_ useSquirrel: Bool = true) -> String {
+    // open squirrel.yaml or hamster.yaml
+    let config = useSquirrel ? rimeAPI.openConfig("squirrel") : rimeAPI.openConfig("hamster")
     if config == nil {
       return ""
     }

--- a/Hamster/Settings/AppSettings.swift
+++ b/Hamster/Settings/AppSettings.swift
@@ -130,6 +130,9 @@ private enum HamsterAppSettingKeys: String {
 
   // 输入嵌入模式
   case enableInputEmbeddedMode = "keyboard.enableInputEmbeddedMode"
+
+  // 使用鼠须管配置
+  case rimeUseSquirrelSettings = "rime.useSquirrelSettings"
 }
 
 public class HamsterAppSettings: ObservableObject {
@@ -165,6 +168,7 @@ public class HamsterAppSettings: ObservableObject {
       HamsterAppSettingKeys.enableNumberNineGrid.rawValue: false,
       HamsterAppSettingKeys.enableKeyboardAutomaticallyLowercase.rawValue: false,
       HamsterAppSettingKeys.enableInputEmbeddedMode.rawValue: false,
+      HamsterAppSettingKeys.rimeUseSquirrelSettings.rawValue: true,
     ])
 
     self.isFirstLaunch = UserDefaults.hamsterSettingsDefault.bool(forKey: HamsterAppSettingKeys.appFirstLaunch.rawValue)
@@ -194,6 +198,7 @@ public class HamsterAppSettings: ObservableObject {
     self.enableNumberNineGrid = UserDefaults.hamsterSettingsDefault.bool(forKey: HamsterAppSettingKeys.enableNumberNineGrid.rawValue)
     self.enableKeyboardAutomaticallyLowercase = UserDefaults.hamsterSettingsDefault.bool(forKey: HamsterAppSettingKeys.enableKeyboardAutomaticallyLowercase.rawValue)
     self.enableInputEmbeddedMode = UserDefaults.hamsterSettingsDefault.bool(forKey: HamsterAppSettingKeys.enableInputEmbeddedMode.rawValue)
+    self.rimeUseSquirrelSettings = UserDefaults.hamsterSettingsDefault.bool(forKey: HamsterAppSettingKeys.rimeUseSquirrelSettings.rawValue)
   }
 
   // App是否首次运行
@@ -468,6 +473,16 @@ public class HamsterAppSettings: ObservableObject {
   // 键盘当前状态
   @Published
   var keyboardStatus: HamsterKeyboardStatus = .normal
+
+  // Rime: 使用鼠须管配置
+  @Published
+  var rimeUseSquirrelSettings: Bool {
+    didSet {
+      Logger.shared.log.info(["AppSettings, rimeUseSquirrelSettings": rimeUseSquirrelSettings])
+      UserDefaults.hamsterSettingsDefault.set(
+        rimeUseSquirrelSettings, forKey: HamsterAppSettingKeys.rimeUseSquirrelSettings.rawValue)
+    }
+  }
 }
 
 public extension UserDefaults {

--- a/HamsterApp/HamsterApp/View/SubView/ColorSchemaView.swift
+++ b/HamsterApp/HamsterApp/View/SubView/ColorSchemaView.swift
@@ -69,7 +69,7 @@ struct ColorSchemaView: View {
     .navigationBarTitleDisplayMode(.inline)
     .onAppear {
       rimeEngine.startRime()
-      self.colorSchemas = rimeEngine.colorSchema()
+      self.colorSchemas = rimeEngine.colorSchema(appSettings.rimeUseSquirrelSettings)
       rimeEngine.shutdownRime()
     }
   }

--- a/HamsterApp/HamsterApp/View/SubView/InputEditorView.swift
+++ b/HamsterApp/HamsterApp/View/SubView/InputEditorView.swift
@@ -37,6 +37,8 @@ struct InputEditorView: View {
 
           CandidateBarShowModeSettingView()
 
+          RimeUseSquirrelSettingsView()
+
           Spacer()
         }
       }
@@ -159,6 +161,26 @@ struct CandidateBarShowModeSettingView: View {
           Text("候选文字体大小: \(appSettings.rimeCandidateTitleFontSize)")
         }
         Spacer()
+      }
+    }
+    .functionCell()
+  }
+}
+
+/// 使用鼠须管配置的设置
+struct RimeUseSquirrelSettingsView: View {
+  @EnvironmentObject var appSettings: HamsterAppSettings
+  var body: some View {
+    VStack {
+      HStack {
+        Toggle(isOn: $appSettings.rimeUseSquirrelSettings) {
+          Text("使用鼠须管配置")
+            .font(.system(size: 16, weight: .bold, design: .rounded))
+        }
+      }
+      HStack {
+        Text("重新部署后生效. 默认使用鼠须管(squirrel)配置. 关闭此选项后, Rime引擎会使用仓(hamster)配置. 您必须保证hamster.yaml存在")
+          .font(.system(size: 14))
       }
     }
     .functionCell()

--- a/HamsterAppTests/Hamster/RimeEngine/RimeEngineTests.swift
+++ b/HamsterAppTests/Hamster/RimeEngine/RimeEngineTests.swift
@@ -72,7 +72,7 @@ final class RimeEngineTests: XCTestCase {
   }
 
   func testColorSchema() throws {
-    let schemaList = rimeEngine.colorSchema()
+    let schemaList = rimeEngine.colorSchema(appSettings.rimeUseSquirrelSettings)
     XCTAssertTrue(!schemaList.isEmpty)
 
     let colorSchema = schemaList.first(where: { $0.schemaName == "solarized_light" })
@@ -83,7 +83,7 @@ final class RimeEngineTests: XCTestCase {
     XCTAssertNotNil(backColor)
     XCTAssertEqual(backColor!.description, "#FBF6E5F0")
 
-    let currentSchemaName = rimeEngine.currentColorSchemaName()
+    let currentSchemaName = rimeEngine.currentColorSchemaName(appSettings.rimeUseSquirrelSettings)
     XCTAssertEqual(currentSchemaName, "metro")
   }
 

--- a/HamsterKeyboard/Keyboard/KeyboardViewController.swift
+++ b/HamsterKeyboard/Keyboard/KeyboardViewController.swift
@@ -347,7 +347,7 @@ extension HamsterKeyboardViewController {
     if name.isEmpty {
       return schema
     }
-    guard let colorSchema = self.rimeEngine.colorSchema().first(where: { $0.schemaName == name }) else {
+    guard let colorSchema = self.rimeEngine.colorSchema(appSettings.rimeUseSquirrelSettings).first(where: { $0.schemaName == name }) else {
       return schema
     }
     Logger.shared.log.info("call getCurrentColorSchema, schameName = \(colorSchema.schemaName)")


### PR DESCRIPTION
## 可以选择使用 `hamster.yaml` 作为配置文件

我先提交草稿，请作者给我修改意见，感谢！

### 动机
可以让高级用户分别维护鼠须管和仓的配置而不发生冲突，特别是以后仓实现了自定义键盘等高级功能，在 UI 上设置会很复杂，可以使用 `hamster.yaml` 作为配置，这些配置就会和鼠须管不兼容。

### 可能有争议的改动
将 UI 的开关放在了“输入功能调整”里，不知道是不是合适。放在这里的另一个问题是，`VStack` 的数量超过 10 个，会编译失败（[参考了这里](https://stackoverflow.com/questions/61178868/swiftui-random-extra-argument-in-call-error)）。于是我将其中的按键设置和候选栏设置用 `Group` 分组了。
