### PR TITLE
fix #113: 清空文本框时清除rime已经输入的字符

### DIFF
--- a/HamsterKeyboard/Keyboard/KeyboardViewController.swift
+++ b/HamsterKeyboard/Keyboard/KeyboardViewController.swift
@@ -190,6 +190,10 @@ open class HamsterKeyboardViewController: KeyboardInputViewController {
   override open func textDidChange(_ textInput: UITextInput?) {
     super.textDidChange(textInput)
     // TODO: 这里添加英文自动转大写功能, 参考: KeyboardContext.preferredAutocapitalizedKeyboardType
+    
+    if (!self.textDocumentProxy.hasText) {
+      self.rimeEngine.reset()
+    }
   }
   
   // MARK: - KeyboardController


### PR DESCRIPTION

After the change:

https://user-images.githubusercontent.com/1658974/233565850-61f012ba-ca73-4d37-8dc1-5a11d44af80f.mp4

