### PR TITLE
For #32: 自动 build 以检查编译错误

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: Build Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Download Frameworks
+        uses: robinraju/release-downloader@v1.7
+        with:
+          repository: "imfuxiao/LibrimeKit"
+          latest: true
+          fileName: "Frameworks.tgz"
+
+      - name: Un-tar Frameworks
+        run: |
+          tar -xzf Frameworks.tgz -C Packages/LibrimeKit
+
+      - name: Build Schemas
+        run: |
+          make schema
+
+      - name: Compile
+        run: |
+          xcodebuild archive -archivePath "Hamster" -scheme "HamsterApp" -sdk "iphoneos" -arch arm64 -configuration Release CODE_SIGNING_ALLOWED=NO
+          BUILT_PATH=$(find Hamster.xcarchive -name '*.app' -type d | head -1)
+          find "$BUILT_PATH" -type d -path '*/Frameworks/*.dylib' -exec codesign --force --sign - --timestamp=none \{\} \;
+          codesign --force --sign - --entitlements "HamsterApp/HamsterApp.entitlements" --timestamp=none "$BUILT_PATH"
+          tar -acf Hamster.xcarchive.tgz Hamster.xcarchive
+
+      - name: Upload xcarchive
+        uses: actions/upload-artifact@v3
+        with:
+          name: Hamster-ios-arm64-xcarchive
+          path: Hamster.xcarchive.tgz


### PR DESCRIPTION
## 已实现的功能
- 当合并到 `main` 分支、提交 pull request 到 `main` 分支时，Github actions 可以自动 build，如果有编译错误，合并之前贡献者需要先修复
- 缓存 `make librime` 的结果，这个步骤需要一个多小时，第一次编译通过后会自动缓存，当上游 `LibrimeKit` 有所改动的时候，可以在 github action 的页面手动运行，并设置 rebuild frameworks 为 `true`，就会重新编译 `LibrimeKit` 并缓存

## 未实现的功能
- 打包为 [AltStore](https://altstore.io/) 可以侧载的 IPA 文件，由于本人能力问题，之前测试打包的 IPA 用 AltStore 侧载之后总是闪退，应该是签名没搞好，希望有这方面的专家可以帮忙解决
- 打包为可上架商店的 IPA，一方面同样是我能力问题，不懂签名方面的知识，另一方面上架商店的 IPA 需要作者的签名

因此，目前这个 workflow 可以为作者把关贡献者是否有编译错误