### PR TITLE
Fix #138: 输入区属性为数字时，初始化为数字键盘

### DIFF
--- a/HamsterKeyboard/Keyboard/KeyboardViewController.swift
+++ b/HamsterKeyboard/Keyboard/KeyboardViewController.swift
@@ -98,6 +98,19 @@ open class HamsterKeyboardViewController: KeyboardInputViewController {
   override public func viewWillSetupKeyboard() {
     super.viewWillSetupKeyboard()
     self.log.debug("viewWillSetupKeyboard() begin")
+
+    // 初始键盘类型
+    if let keyboardType = self.textDocumentProxy.keyboardType {
+      switch keyboardType {
+      // 数字键盘
+      case .numberPad, .numbersAndPunctuation, .phonePad, .decimalPad, .asciiCapableNumberPad:
+        self.keyboardContext.keyboardType = .numeric
+      // 默认键盘
+      default:
+        break
+      }
+    }
+    
     let hamsterKeyboard = HamsterKeyboard(keyboardInputViewController: self)
       .environmentObject(self.rimeEngine)
       .environmentObject(self.appSettings)


### PR DESCRIPTION
Fix #138 

## 九宫格数字键盘
https://user-images.githubusercontent.com/1658974/234726877-a4778bbe-fdf6-4979-98f4-28a47852a1bb.mp4 

## 普通数字键盘
https://user-images.githubusercontent.com/1658974/234726894-e9498dab-2f13-42e0-84e7-752457f8c137.mp4

