### PR TITLE
feat: 『输入功能调整』页面添加 「空格横向移动速度」选项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ xcuserdata/
 ## Xcode 8 and earlier
 *.xcscmblueprint
 *.xccheckout
+.history

--- a/Hamster/Settings/AppSettings.swift
+++ b/Hamster/Settings/AppSettings.swift
@@ -144,6 +144,10 @@ private enum HamsterAppSettingKeys: String {
 
   // 使用鼠须管配置
   case rimeUseSquirrelSettings = "rime.useSquirrelSettings"
+    
+    
+  // 空格横向移动速度
+  case spaceXSpeed = "space.x.speed"
 }
 
 public class HamsterAppSettings: ObservableObject {
@@ -182,6 +186,7 @@ public class HamsterAppSettings: ObservableObject {
       HamsterAppSettingKeys.enableKeyboardAutomaticallyLowercase.rawValue: false,
       HamsterAppSettingKeys.enableInputEmbeddedMode.rawValue: false,
       HamsterAppSettingKeys.rimeUseSquirrelSettings.rawValue: true,
+      HamsterAppSettingKeys.spaceXSpeed.rawValue: 10,
     ])
 
     self.isFirstLaunch = UserDefaults.hamsterSettingsDefault.bool(forKey: HamsterAppSettingKeys.appFirstLaunch.rawValue)
@@ -201,6 +206,7 @@ public class HamsterAppSettings: ObservableObject {
     self.rimeMaxCandidateSize = Int32(UserDefaults.hamsterSettingsDefault.integer(forKey: HamsterAppSettingKeys.rimeMaxCandidateSize.rawValue))
     self.rimeCandidateTitleFontSize = UserDefaults.hamsterSettingsDefault.integer(forKey: HamsterAppSettingKeys.rimeCandidateTitleFontSize.rawValue)
     self.rimeCandidateCommentFontSize = UserDefaults.hamsterSettingsDefault.integer(forKey: HamsterAppSettingKeys.rimeCandidateCommentFontSize.rawValue)
+    self.spaceXSpeed = UserDefaults.hamsterSettingsDefault.integer(forKey: HamsterAppSettingKeys.spaceXSpeed.rawValue)
 
     // 对数组类型且为Struct值需要特殊处理
     if let data = UserDefaults.hamsterSettingsDefault.data(forKey: HamsterAppSettingKeys.rimeUserSelectSchema.rawValue) {
@@ -547,6 +553,14 @@ public class HamsterAppSettings: ObservableObject {
         rimeUseSquirrelSettings, forKey: HamsterAppSettingKeys.rimeUseSquirrelSettings.rawValue)
     }
   }
+    
+  @Published
+  var spaceXSpeed: Int {
+    didSet {
+      UserDefaults.hamsterSettingsDefault.set(
+        spaceXSpeed, forKey: HamsterAppSettingKeys.spaceXSpeed.rawValue)
+      }
+    }
 }
 
 public extension UserDefaults {

--- a/HamsterApp/HamsterApp/View/SubView/InputEditorView.swift
+++ b/HamsterApp/HamsterApp/View/SubView/InputEditorView.swift
@@ -164,6 +164,16 @@ struct CandidateBarShowModeSettingView: View {
       }
     }
     .functionCell()
+
+    VStack {
+      HStack {
+        Stepper(value: $appSettings.spaceXSpeed, in: 1 ... 30, step: 1) {
+          Text("空格横向移动速度(越小越快): \(appSettings.spaceXSpeed)")
+        }
+        Spacer()
+      }
+    }
+    .functionCell()
   }
 }
 

--- a/HamsterKeyboard/Keyboard/Gestures/HamsterSlidingGestureHandler.swift
+++ b/HamsterKeyboard/Keyboard/Gestures/HamsterSlidingGestureHandler.swift
@@ -31,14 +31,14 @@ class HamsterSlidingGestureHandler: SlideGestureHandler {
     keyboardContext: KeyboardContext,
     appSettings: HamsterAppSettings,
     // 滑动敏感度：滑动超过阈值才有效
-    sensitivityX: SpaceDragSensitivity = .custom(points: 50),
+    sensitivityX: SpaceDragSensitivity = .custom(points: 10),
     sensitivityY: SpaceDragSensitivity = .custom(points: 20),
     action: @escaping (KeyboardAction, SlidingDirection, Int) -> Void
   ) {
     self.keyboardContext = keyboardContext
     self.appSettings = appSettings
-    self.sensitivityY = sensitivityX
-    self.sensitivityX = sensitivityY
+    self.sensitivityY = sensitivityY
+    self.sensitivityX = .custom(points: appSettings.spaceXSpeed)
     self.action = action
   }
 
@@ -81,9 +81,8 @@ class HamsterSlidingGestureHandler: SlideGestureHandler {
     let dragDeltaX = startLocation.x - currentLocation.x
     let dragOffsetY = Int(dragDeltaY / CGFloat(sensitivityY.points))
     let dragOffsetX = Int(dragDeltaX / CGFloat(sensitivityX.points))
-
     // x，y轴都没有超过阈值，则不视做一次滑动
-    if dragOffsetX == currentDragOffsetY && dragOffsetY == currentDragOffsetX {
+    if dragOffsetX == currentDragOffsetX && dragOffsetY == currentDragOffsetY {
       return
     }
 


### PR DESCRIPTION
可以设置空格横向移动速度，之前设置的 `50` 其实生效的是 y 的 `20`
![CleanShot 2023-04-28 at 23 27 08](https://user-images.githubusercontent.com/15698129/235190640-a04a6b3b-cebd-4903-9913-ae5c0bb77865.gif)
