### PR TITLE
iPad布局

### DIFF
--- a/General/Lab/Keybaord/Input/ChineseInputSetProvider.swift
+++ b/General/Lab/Keybaord/Input/ChineseInputSetProvider.swift
@@ -30,8 +30,12 @@ public extension NumericInputSet {
   static func chinese() -> NumericInputSet {
     NumericInputSet(rows: [
       .init(chars: "1234567890"),
-      .init(phone: "-/：；（）￥@“”", pad: "-/：；（）￥@“”"),
-      .init(phone: "。，、？！.", pad: "。，、？！.")
+      .init(
+        phone: "-/：；（）￥@“”",
+        pad: "%-～…、；：，。"),
+      .init(
+        phone: "。，、？！.",
+        pad: "%-～…、；：，。")
     ])
   }
 
@@ -48,12 +52,15 @@ public extension NumericInputSet {
 public extension SymbolicInputSet {
   static func chinese() -> SymbolicInputSet {
     SymbolicInputSet(rows: [
-      .init(phone: "【】｛｝#%^*+=", pad: "【】｛｝#%^*+="),
+      .init(
+        phone: "【】｛｝#%^*+=",
+        pad: "^_｜\\<>{},."),
       .init(
         phone: "_—\\｜～《》$&·",
-        pad: "_—\\｜～《》$&·"
-      ),
-      .init(phone: "…，。？！‘", pad: "…，。？！‘")
+        pad: "&$€*【】「」•"),
+      .init(
+        phone: "…，。？！‘",
+        pad: "。—+=·《》！？")
     ])
   }
 }

--- a/General/Lab/Keybaord/Layout/Providers/HamsterStandardKeyboardLayoutProvider.swift
+++ b/General/Lab/Keybaord/Layout/Providers/HamsterStandardKeyboardLayoutProvider.swift
@@ -24,7 +24,10 @@ class HamsterStandardKeyboardLayoutProvider: StandardKeyboardLayoutProvider {
    The layout provider that is used for iPad devices.
    */
   lazy var hamsteriPadProvider = HamsteriPadKeyboardLayoutProvider(
-    inputSetProvider: inputSetProvider)
+    inputSetProvider: hamsterInputSetProvider,
+    appSettings: appSettings,
+    rimeContext: rimeContext
+  )
 
   /**
    The layout provider that is used for iPhone devices.

--- a/General/Lab/Keybaord/Layout/Providers/iPadKeyboardLayoutProvider.swift
+++ b/General/Lab/Keybaord/Layout/Providers/iPadKeyboardLayoutProvider.swift
@@ -1,5 +1,103 @@
 import Foundation
 import KeyboardKit
 
-// TODO: iPAD键盘布局调整
-class HamsteriPadKeyboardLayoutProvider: iPadKeyboardLayoutProvider {}
+class HamsteriPadKeyboardLayoutProvider: iPadKeyboardLayoutProvider {
+  init(inputSetProvider: HamsterInputSetProvider, appSettings: HamsterAppSettings, rimeContext: RimeContext) {
+    self.appSettings = appSettings
+    self.rimeContext = rimeContext
+    self.hamsterInputSetProvider = inputSetProvider
+    super.init(inputSetProvider: inputSetProvider)
+  }
+  
+  let appSettings: HamsterAppSettings
+  let rimeContext: RimeContext
+  let hamsterInputSetProvider: HamsterInputSetProvider
+  
+  /**
+   Get the keyboard layout item width of a certain `action`
+   for the provided `context`, `row` and row `index`.
+   */
+  override func itemSizeWidth(
+    for action: KeyboardAction, row: Int, index: Int, context: KeyboardContext) -> KeyboardLayoutItemWidth
+  {
+    // 自定义键盘类型宽度一致
+    if case .custom = context.keyboardType {
+      return .input
+    }
+    
+    switch action {
+    // 自定义按键
+    case .image, .custom:
+      return .input
+    default:
+      return super.itemSizeWidth(for: action, row: row, index: index, context: context)
+    }
+  }
+  
+  /**
+   The actions to add to the bottommost row.
+   */
+  override func bottomActions(for context: KeyboardContext) -> KeyboardActions {
+    var result = KeyboardActions()
+    
+    // 根据键盘类型不同显示不同的切换键: 如数字键盘/字母键盘等切换键
+    if let action = keyboardSwitchActionForBottomRow(for: context) {
+      result.append(action)
+    }
+
+    // 不同输入法切换键（小地球）
+    if context.needsInputModeSwitchKey {
+      result.append(.nextKeyboard)
+    }
+    
+    // 听写键
+    if context.hasDictationKey {
+      if let action = context.keyboardDictationReplacement {
+        result.append(action)
+      } else {
+        result.append(.dictation)
+      }
+    }
+    
+    // 底部根据配置, 添加自定义功能键
+    if appSettings.showSpaceLeftButton {
+      result.append(.custom(named: appSettings.spaceLeftButtonValue))
+    }
+    
+    // 空格左侧添加中英文切换按键
+    if appSettings.showSpaceRightSwitchLanguageButton && appSettings.switchLanguageButtonInSpaceLeft && context.keyboardType.isAlphabetic {
+      result.append(switchLanguageButtonAction())
+    }
+    
+    // 空格键
+    result.append(.space)
+    
+    // 底部根据配置, 添加自定义功能键
+    if appSettings.showSpaceRightButton {
+      result.append(.custom(named: appSettings.spaceRightButtonValue))
+    }
+
+    // 空格右侧添加中英文切换按键
+    if appSettings.showSpaceRightSwitchLanguageButton && !appSettings.switchLanguageButtonInSpaceLeft && context.keyboardType.isAlphabetic {
+      result.append(switchLanguageButtonAction())
+    }
+    
+    // 根据键盘类型不同显示不同的切换键: 如数字键盘/字母键盘等切换键
+    if let action = keyboardSwitchActionForBottomRow(for: context) {
+      result.append(action)
+    }
+    
+    // 收起键盘
+    result.append(.dismissKeyboard)
+    
+    return result
+  }
+
+  // 中英文切换按钮Action
+  func switchLanguageButtonAction() -> KeyboardAction {
+    return .image(
+      description: "中英切换",
+      keyboardImageName: "",
+      imageName: KeyboardConstant.ImageName.switchLanguage)
+  }
+}


### PR DESCRIPTION
1. 显示自定义空格左右按键
2. 定义数字和符号键盘

| 键盘 | 截图 |
|--|--|
| 主键盘 | ![Simulator Screenshot - iPad Air (5th generation) - 2023-06-26 at 00 12 05](https://github.com/imfuxiao/Hamster/assets/1658974/769ea769-c83c-498a-8286-1c30fc5a9be9) |
| 数字键盘 | ![Simulator Screenshot - iPad Air (5th generation) - 2023-06-26 at 00 12 08](https://github.com/imfuxiao/Hamster/assets/1658974/07da6523-6806-40b6-b848-9f6e92847849) |
| 符号键盘 | ![Simulator Screenshot - iPad Air (5th generation) - 2023-06-26 at 00 12 10](https://github.com/imfuxiao/Hamster/assets/1658974/437470d7-4e61-49d2-ad04-807c5852b465) |