### PR TITLE
fix #368：成对上屏功虽能支持两个以上符号但光标无法居中

### DIFF
--- a/Packages/HamsterKeyboardKit/Sources/Controller/KeyboardInputViewController.swift
+++ b/Packages/HamsterKeyboardKit/Sources/Controller/KeyboardInputViewController.swift
@@ -928,13 +928,20 @@ private extension KeyboardInputViewController {
 
     // 检测光标是否需要回退
     if keyboardContext.cursorBackOfSymbols(key: text) {
-      // 检测是否有选中的文字，可以居中的光标将自动包裹选中的文本
-      if text.count == 2, let selectText = textDocumentProxy.selectedText {
-        textDocumentProxy.insertText("\(String(text.first!))\(selectText)\(String(text.last!))")
-      } else {
-        textDocumentProxy.insertText(text)
-        self.adjustTextPosition(byCharacterOffset: -1)
-      }
+        // 检测是否有选中的文字，可以居中的光标将自动包裹选中的文本
+        if text.count > 0 && text.count % 2 == 0 {
+            let selectText = textDocumentProxy.selectedText ?? ""
+            let halfLength = text.count / 2
+            let firstHalf = String(text.prefix(halfLength))
+            let secondHalf = String(text.suffix(halfLength))
+            textDocumentProxy.insertText("\(firstHalf)\(selectText)\(secondHalf)")
+            // 如果选中的文字为空，将光标挪到中间，否则不用移动
+            let offset = selectText.count == 0 ? halfLength : 0
+            self.adjustTextPosition(byCharacterOffset: -offset)
+        } else {
+            textDocumentProxy.insertText(text)
+            self.adjustTextPosition(byCharacterOffset: -1)
+        }
     } else {
       textDocumentProxy.insertText(text)
     }


### PR DESCRIPTION
成对上屏符号如果是两个及以上符号时区分两种场景：
1. 无选中文字，这种场景下应该是光标居中，比如 [[]] 这种很常见的双链链接符号输入后应该居中方便填写
2. 有选中文字，这种场景下被框住的内容已经有比较明确的范围了，光标更应该在整体文字后 -- 这里可以讨论，我自己想了一下，如果是需要给已有文字加前后符号的场景大都是不会再修改中间内容的